### PR TITLE
Fix dispatch example

### DIFF
--- a/lib/useReducer.lua
+++ b/lib/useReducer.lua
@@ -57,9 +57,13 @@ local diffTables = require(Package.diffTables)
 	end
 
 	if increaseCondition then
-		dispatch("increase")
+		dispatch({
+			type = "increase",
+		})
 	elseif decreaseCondition then
-		dispatch("decrease")
+		dispatch({
+			type = "decrease",
+		})
 	end
 	```
 


### PR DESCRIPTION
## Proposed changes

This fixes the dispatch example to use the `type` field of the action as our docs explain.
