### PR TITLE
Fix peer dependency scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ If you're currently using the scope `lasttalon/matter-hooks`, this is the same
 package. You can migrate by changing your `wally.toml` file to use the scope
 `matter-ecs/matter-hooks`.
 
+If you have migrated to `ecs-matter/matter`, you should also upgrade to
+`ecs-matter/matter-hooks@0.2.0` or newer. This version of Matter Hooks is
+compatible with the `ecs-matter/matter` package scope as a peer dependency.
+
 ## Building
 
 Before building, you'll need to install all dependencies using [Wally].

--- a/test.project.json
+++ b/test.project.json
@@ -10,6 +10,9 @@
 					"$path": "lib"
 				}
 			},
+			"DevPackages": {
+				"$path": "DevPackages"
+			},
 			"tests": {
 				"$path": "tests"
 			}

--- a/tests/runners/tests.lua
+++ b/tests/runners/tests.lua
@@ -1,5 +1,5 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local TestEZ = require(ReplicatedStorage.Packages.TestEZ)
+local TestEZ = require(ReplicatedStorage.DevPackages.TestEZ)
 
 local function test(roots)
 	print()

--- a/wally.toml
+++ b/wally.toml
@@ -11,8 +11,11 @@ registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 exclude = ["*.spec.lua", "*.dev.lua", "tests", "docs"]
 
+[place]
+shared-packages = "game.ReplicatedStorage.Packages"
+
 [dependencies]
-Matter = "evaera/matter@0.6.2"
-TestEZ = "roblox/testez@0.4.1" # This is needed currently because Matter has this as a regular dependency.
+Matter = "matter-ecs/matter@>=0.6.2, <0.8.0"
 
 [dev-dependencies]
+TestEZ = "roblox/testez@0.4.1"


### PR DESCRIPTION
## Proposed changes

Currently, because this is a peer dependency and it depends on the specific `matter-ecs/matter` scope, Wally will not warn about installation with mismatched packages, i.e. using `matter-ecs/matter` with the old v0.1 Matter Hooks. This adds updated dependencies and a note about it in the readme.
