### PR TITLE
Check already streamed instances in addition to new descendants.

### DIFF
--- a/lib/useStream.lua
+++ b/lib/useStream.lua
@@ -174,8 +174,8 @@ local function useStream(id: unknown, options: StreamOptions?): () -> (number?, 
 		local options = normalizeOptions(options)
 		storage.queue = Queue.new()
 		storage.trackedInstances = {}
-
-		storage.addedConnection = Workspace.DescendantAdded:Connect(function(instance: Instance)
+		
+		local function newDescendant(instance: Instance)
 			if instance:GetAttribute(options.attribute) ~= id then
 				return
 			end
@@ -204,7 +204,12 @@ local function useStream(id: unknown, options: StreamOptions?): () -> (number?, 
 			for _, descendant in instance:GetDescendants() do
 				storage.queue:push(streamInEvent(descendant, true))
 			end
-		end)
+		end
+		
+		storage.addedConnection = Workspace.DescendantAdded:Connect(newDescendant)
+		for _, instance: Instance in Workspace:GetDescendants() do
+			newDescendant(instance)
+		end
 
 		storage.removingConnection = Workspace.DescendantRemoving:Connect(
 			function(instance: Instance)


### PR DESCRIPTION
Similar to how :queryChanged returns a record of all records prior to the first call to queryChanged, it would be useful for the result of useStream to do an initial check for any entities that streamed prior to my initial call.